### PR TITLE
Filter list of length 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,9 @@ const lb4Provider = (apiUrl, headers = () => {}, idParamApi='_id', idParamAdmin=
                 }
                 return { data: r.map(el => el[idParamAdmin]) };
             }
-            _.set(filter, `${idParamApi}.inq`, ids);
+            if (ids.length > 1) {
+                _.set(filter, `${idParamApi}.inq`, ids);
+            }
         }
         if (filter && Object.keys(filter).length > 0) {
             if ( [ UPDATE_MANY ].indexOf(type) > -1 )


### PR DESCRIPTION
If an array of ids has a length of one, the inq filter will trigger the following error in loopback 4:
`Error: Value is not an array or object with sequential numeric indices`
In the event that there is only one item to filter by in the list, the provider should not set an inq filter.